### PR TITLE
Py36/django1.11/celery4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   matrix:
     - TOXENV=py27-django18
     - TOXENV=py27-django111
+    - TOXENV=py36-django18
     - TOXENV=py36-django111
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,6 @@ sudo: false
 python: 2.7
 env:
   matrix:
-    - TOXENV=py27-django12
-    - TOXENV=py27-django13
-    - TOXENV=py27-django14
-    - TOXENV=py27-django15
-    - TOXENV=py27-django16
-    - TOXENV=py27-django17
     - TOXENV=py27-django18
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,10 @@ sudo: false
 python: 2.7
 env:
   matrix:
-    - TOXENV=py26-django12
     - TOXENV=py27-django12
-    - TOXENV=py26-django13
     - TOXENV=py27-django13
-    - TOXENV=py26-django14
     - TOXENV=py27-django14
-    - TOXENV=py26-django15
     - TOXENV=py27-django15
-    - TOXENV=py26-django16
     - TOXENV=py27-django16
     - TOXENV=py27-django17
     - TOXENV=py27-django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: python
 sudo: false
-python: 2.7
+python:
+    - 2.7
+    - 3.6
 env:
   matrix:
     - TOXENV=py27-django18
     - TOXENV=py27-django111
+    - TOXENV=py36-django111
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
     - TOXENV=py27-django16
     - TOXENV=py27-django17
     - TOXENV=py27-django18
-    - TOXENV=py27-celery22
-    - TOXENV=py27-celery30
 
 install:
   - pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python: 2.7
 env:
   matrix:
     - TOXENV=py27-django18
+    - TOXENV=py27-django111
 
 install:
   - pip install tox

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 # Requirements
 
 * Python (2.7)
-* Celery (2.2, 3.0, 3.1)
+* Celery (3.1)
 * Django (1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@
 
 * Python (2.7)
 * Celery (4.1)
-* Django (1.8)
+* Django (1.8, 1.11)

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 # Requirements
 
 * Python (2.7)
-* Celery (3.1)
-* Django (1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8)
+* Celery (4.1)
+* Django (1.8)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 # Requirements
 
-* Python (2.6, 2.7)
+* Python (2.7)
 * Celery (2.2, 3.0, 3.1)
 * Django (1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8)

--- a/beproud/django/__init__.py
+++ b/beproud/django/__init__.py
@@ -3,5 +3,6 @@ try:
     __import__('pkg_resources').declare_namespace(__name__)
 except ImportError:
     from pkgutil import extend_path
-    __path__ = locals()['__path__'] # make PyFlakes happy
+    # make PyFlakes happy
+    __path__ = locals()['__path__']
     __path__ = extend_path(__path__, __name__)

--- a/beproud/django/mailer/api.py
+++ b/beproud/django/mailer/api.py
@@ -45,7 +45,7 @@ __all__ = (
     'BadHeaderError',
 )
 
-utf8_charset = charset.Charset('UTF-8')
+utf8_charset = charset.Charset('utf-8')
 
 # ガラケの場合は base64 じゃないとダメなやつが多いので、デフォルトで BASE64を使う。
 if not getattr(settings, "EMAIL_USE_BASE64_FOR_UTF8", True):

--- a/beproud/django/mailer/api.py
+++ b/beproud/django/mailer/api.py
@@ -95,25 +95,6 @@ logger = logging.getLogger(getattr(settings, "EMAIL_LOGGER", ""))
 
 
 class EmailMessage(django_mail.EmailMessage):
-    def __init__(self, subject='', body='', from_email=None, to=None, bcc=None,
-                 connection=None, attachments=None, headers=None, cc=None):
-        super(EmailMessage, self).__init__(
-            subject=subject,
-            body=body,
-            from_email=from_email,
-            to=to,
-            cc=cc,
-            bcc=bcc,
-            connection=connection,
-            attachments=attachments,
-            headers=headers,
-        )
-
-    def get_connection(self, fail_silently=False):
-        if not self.connection:
-            self.connection = get_connection(fail_silently=fail_silently)
-        return self.connection
-
     def message(self):
         encoding = self.encoding or getattr(settings, "EMAIL_CHARSET", settings.DEFAULT_CHARSET)
         msg = SafeMIMEText(self.body, self.content_subtype, encoding)

--- a/beproud/django/mailer/api.py
+++ b/beproud/django/mailer/api.py
@@ -1,13 +1,16 @@
 #:coding=utf-8:
-
 import sys
 import traceback
 import logging
-from StringIO import StringIO
+import six
 
-from email import Encoders, charset, generator, message_from_string
-from email.Utils import formatdate
-from email.MIMEBase import MIMEBase
+StringIO = six.StringIO
+
+from email import encoders, charset, generator, message_from_string
+from email.utils import formatdate
+from six.moves import email_mime_base
+MIMEBase = email_mime_base.MIMEBase
+
 from email.mime.text import MIMEText
 from email.message import Message
 
@@ -146,7 +149,7 @@ class EmailMessage(django_mail.EmailMessage):
             # Encode non-text attachments with base64.
             attachment = MIMEBase(basetype, subtype)
             attachment.set_payload(content)
-            Encoders.encode_base64(attachment)
+            encoders.encode_base64(attachment)
         return attachment
 
     def send(self, *args, **kwargs):

--- a/beproud/django/mailer/api.py
+++ b/beproud/django/mailer/api.py
@@ -52,14 +52,12 @@ if not getattr(settings, "EMAIL_USE_BASE64_FOR_UTF8", True):
     # some spam filters.
     utf8_charset.body_encoding = None
 
-_old_safemimetext = django_mail.SafeMIMEText
 
-
-class SafeMIMEText(_old_safemimetext):
+class SafeMIMEText(django_mail.SafeMIMEText):
     def __init__(self, text, subtype, charset):
         self.encoding = charset
         # NOTE: utf8 でも utf-8 でも対応する
-        if charset.upper().replace("-", "") == 'UTF8':
+        if charset.upper() in  ('UTF8', 'UTF-8'):
             # Unfortunately, Python doesn't support setting a Charset instance
             # as MIMEText init parameter (http://bugs.python.org/issue16324).
             # We do it manually and trigger re-encoding of the payload.

--- a/beproud/django/mailer/api.py
+++ b/beproud/django/mailer/api.py
@@ -3,18 +3,14 @@ import sys
 import traceback
 import logging
 import six
-
-StringIO = six.StringIO
-
-from email import encoders, charset, generator, message_from_string
-from email.utils import formatdate
 from six.moves import email_mime_base
-MIMEBase = email_mime_base.MIMEBase
 
-from email.mime.text import MIMEText
+from email import encoders, charset, message_from_string
+from email.utils import formatdate
 from email.message import Message
+from email.mime.text import MIMEText
+from email.mime.message import MIMEMessage
 
-import django
 from django.core import mail as django_mail
 from django.template.loader import render_to_string
 from django.conf import settings
@@ -45,6 +41,9 @@ __all__ = (
     'BadHeaderError',
 )
 
+StringIO = six.StringIO
+MIMEBase = email_mime_base.MIMEBase
+
 utf8_charset = charset.Charset('utf-8')
 
 # ガラケの場合は base64 じゃないとダメなやつが多いので、デフォルトで BASE64を使う。
@@ -54,6 +53,7 @@ if not getattr(settings, "EMAIL_USE_BASE64_FOR_UTF8", True):
     utf8_charset.body_encoding = None
 
 _old_safemimetext = django_mail.SafeMIMEText
+
 
 class SafeMIMEText(_old_safemimetext):
     def __init__(self, text, subtype, charset):
@@ -71,6 +71,7 @@ class SafeMIMEText(_old_safemimetext):
         else:
             MIMEText.__init__(self, text, subtype, charset)
 
+
 django_mail.SafeMIMEText = SafeMIMEText
 try:
     from django.core.mail import message as django_mail_message
@@ -78,14 +79,13 @@ try:
 except ImportError:
     pass
 
+
 SafeMIMEMultipart = django_mail.SafeMIMEMultipart
 BadHeaderError = django_mail.BadHeaderError
 get_connection = django_mail.get_connection
 forbid_multi_line_headers = django_mail.forbid_multi_line_headers
 make_msgid = django_mail.make_msgid
 
-
-from email.mime.message import MIMEMessage
 
 class SafeMIMEMessage(MIMEMessage):
     def __setitem__(self, name, val):

--- a/beproud/django/mailer/models.py
+++ b/beproud/django/mailer/models.py
@@ -24,32 +24,32 @@ if six.PY2:
 # Python charset => mail header charset mapping
 # TODO: Add more encodings
 CHARSETS = getattr(settings, "EMAIL_CHARSETS", {
-    'UTF-8': {
+    'utf-8': {
         'header_enc': SHORTEST,
         'body_enc': BASE64,
         'output_charset': None,
     },
-    'SHIFT-JIS': {
+    'shift-jis': {
         'header_enc': BASE64,
         'body_enc': None,
         'output_charset': None,
     },
-    'ISO-2022-JP': {
+    'iso-2022-jp': {
         'header_enc': BASE64,
         'body_enc': None,
         'output_charset': None,
     },
-    'ISO-2022-JP-2': {
+    'iso-2022-jp-2': {
         'header_enc': BASE64,
         'body_enc': None,
         'output_charset': None,
     },
-    'ISO-2022-JP-3': {
+    'iso-2022-jp-3': {
         'header_enc': BASE64,
         'body_enc': None,
         'output_charset': None,
     },
-    'ISO-2022-JP-EXT': {
+    'iso-2022-jp-ext': {
         'header_enc': BASE64,
         'body_enc': None,
         'output_charset': None,
@@ -57,68 +57,68 @@ CHARSETS = getattr(settings, "EMAIL_CHARSETS", {
 })
 
 ALIASES = getattr(settings, "EMAIL_CHARSET_ALIASES", {
-    # UTF-8
-    "utf8": "UTF-8",
-    "utf_8": "UTF-8",
-    "U8": "UTF-8",
-    "UTF": "UTF-8",
-    "utf8": "UTF-8",
-    "utf-8": "UTF-8",
+    # utf-8
+    "utf8": "utf-8",
+    "utf_8": "utf-8",
+    "U8": "utf-8",
+    "UTF": "utf-8",
+    "utf8": "utf-8",
+    "utf-8": "utf-8",
 
     # Shift-JIS
-    "cp932": "SHIFT-JIS",
-    "932": "SHIFT-JIS",
-    "ms932": "SHIFT-JIS",
-    "mskanji": "SHIFT-JIS",
-    "ms-kanji": "SHIFT-JIS",
+    "cp932": "shift-jis",
+    "932": "shift-jis",
+    "ms932": "shift-jis",
+    "mskanji": "shift-jis",
+    "ms-kanji": "shift-jis",
 
-    "shift_jis": "SHIFT-JIS",
-    "csshiftjis": "SHIFT-JIS",
-    "shiftjis": "SHIFT-JIS",
-    "sjis": "SHIFT-JIS",
-    "s_jis": "SHIFT-JIS",
+    "shift_jis": "shift-jis",
+    "csshiftjis": "shift-jis",
+    "shiftjis": "shift-jis",
+    "sjis": "shift-jis",
+    "s_jis": "shift-jis",
 
-    #"shift_jis_2004": "SHIFT-JIS",
-    #"shiftjis2004": "SHIFT-JIS",
-    #"sjis_2004": "SHIFT-JIS",
-    #"sjis2004": "SHIFT-JIS",
+    #"shift_jis_2004": "shift-jis",
+    #"shiftjis2004": "shift-jis",
+    #"sjis_2004": "shift-jis",
+    #"sjis2004": "shift-jis",
     #
-    #"shift_jisx0213": "SHIFT-JIS",
-    #"shiftjisx0213": "SHIFT-JIS",
-    #"sjisx0213": "SHIFT-JIS",
-    #"s_jisx0213": "SHIFT-JIS",
+    #"shift_jisx0213": "shift-jis",
+    #"shiftjisx0213": "shift-jis",
+    #"sjisx0213": "shift-jis",
+    #"s_jisx0213": "shift-jis",
 
     # ISO-2022-JP
-    "iso2022_jp": "ISO-2022-JP",
-    "scsiso2022jp": "ISO-2022-JP",
-    "iso2022jp": "ISO-2022-JP",
-    "iso-2022-jp": "ISO-2022-JP",
-    "iso-2022-jp": "ISO-2022-JP",
-    "iso-2022-jp-1": "ISO-2022-JP",
+    "iso2022_jp": "iso-2022-jp",
+    "scsiso2022jp": "iso-2022-jp",
+    "iso2022jp": "iso-2022-jp",
+    "iso-2022-jp": "iso-2022-jp",
+    "iso-2022-jp": "iso-2022-jp",
+    "iso-2022-jp-1": "iso-2022-jp",
 
-    "iso-2022-jp-2": "ISO-2022-JP-2",
-    "iso2022_jp_2": "ISO-2022-JP-2",
-    "iso2022jp-2": "ISO-2022-JP-2",
-    "iso2022_jp_2004": "ISO-2022-JP-2",
-    "iso2022jp-2004": "ISO-2022-JP-2",
-    "iso-2022-jp-2004": "ISO-2022-JP-2",
+    "iso-2022-jp-2": "iso-2022-jp-2",
+    "iso2022_jp_2": "iso-2022-jp-2",
+    "iso2022jp-2": "iso-2022-jp-2",
+    "iso2022_jp_2004": "iso-2022-jp-2",
+    "iso2022jp-2004": "iso-2022-jp-2",
+    "iso-2022-jp-2004": "iso-2022-jp-2",
 
-    "iso2022_jp_3": "ISO-2022-JP-3",
-    "iso2022jp-3": "ISO-2022-JP-3",
-    "iso-2022-jp-3": "ISO-2022-JP-3",
+    "iso2022_jp_3": "iso-2022-jp-3",
+    "iso2022jp-3": "iso-2022-jp-3",
+    "iso-2022-jp-3": "iso-2022-jp-3",
 
     # TODO: 携帯は対応してないと
-    "iso2022_jp_ext": "ISO-2022-JP-EXT",
-    "iso2022jp-ext": "ISO-2022-JP-EXT",
-    "iso-2022-jp-ext": "ISO-2022-JP-EXT",
+    "iso2022_jp_ext": "iso-2022-jp-ext",
+    "iso2022jp-ext": "iso-2022-jp-ext",
+    "iso-2022-jp-ext": "iso-2022-jp-ext",
 })
 CODECS = getattr(settings, "EMAIL_CHARSET_CODECS", {
-    'ISO-2022-JP': 'iso-2022-jp',
-    'ISO-2022-JP-2': 'iso-2022-jp-2',
-    'ISO-2022-JP-3': 'iso-2022-jp-3',
-    'ISO-2022-JP-EXT': 'iso2022jp-ext',
-    'UTF-8': 'utf-8',
-    'SHIFT-JIS': 'cp932',
+    'iso-2022-jp': 'iso-2022-jp',
+    'iso-2022-jp-2': 'iso-2022-jp-2',
+    'iso-2022-jp-3': 'iso-2022-jp-3',
+    'iso-2022-jp-ext': 'iso2022jp-ext',
+    'utf-8': 'utf-8',
+    'shift-jis': 'cp932',
 })
 
 

--- a/beproud/django/mailer/models.py
+++ b/beproud/django/mailer/models.py
@@ -26,7 +26,7 @@ if six.PY2:
 CHARSETS = getattr(settings, "EMAIL_CHARSETS", {
     'utf-8': {
         'header_enc': SHORTEST,
-        'body_enc': BASE64,
+        'body_enc': None,
         'output_charset': None,
     },
     'shift-jis': {

--- a/beproud/django/mailer/models.py
+++ b/beproud/django/mailer/models.py
@@ -15,9 +15,10 @@ __all__ = ('init_mailer',)
 # Uppercase charset aliases cause inequality checks
 # with input and output encodings to fail thus causing
 # double encoding of base64 body text parts.
-def _safe_str(self):
-    return self.input_charset
-charset.Charset.__str__ = _safe_str
+if six.PY2:
+    def _safe_str(self):
+        return self.input_charset
+    charset.Charset.__str__ = _safe_str
 
 
 # Python charset => mail header charset mapping

--- a/beproud/django/mailer/models.py
+++ b/beproud/django/mailer/models.py
@@ -1,4 +1,5 @@
 #:coding=utf-8:
+import six
 
 from django.conf import settings
 
@@ -122,15 +123,15 @@ CODECS = getattr(settings, "EMAIL_CHARSET_CODECS", {
 
 def init_mailer():
     if CHARSETS:
-        for canonical, charset_dict in CHARSETS.iteritems():
+        for canonical, charset_dict in six.iteritems(CHARSETS):
             add_charset(canonical, **charset_dict)
 
     if ALIASES:
-        for alias, canonical in ALIASES.iteritems():
+        for alias, canonical in six.iteritems(ALIASES):
             add_alias(alias, canonical)
 
     if CODECS:
-        for canonical, codec_name in CODECS.iteritems():
+        for canonical, codec_name in six.iteritems(CODECS):
             add_codec(canonical, codec_name)
 
 init_mailer()

--- a/beproud/django/mailer/models.py
+++ b/beproud/django/mailer/models.py
@@ -135,4 +135,5 @@ def init_mailer():
         for canonical, codec_name in six.iteritems(CODECS):
             add_codec(canonical, codec_name)
 
+
 init_mailer()

--- a/beproud/django/mailer/signals.py
+++ b/beproud/django/mailer/signals.py
@@ -1,5 +1,4 @@
 #:coding=utf-8:
-
 from django.dispatch import Signal
 
 mail_pre_send = Signal(providing_args=["message"])

--- a/beproud/django/mailer/tasks.py
+++ b/beproud/django/mailer/tasks.py
@@ -1,6 +1,4 @@
 #:coding=utf-8:
-from django.conf import settings
-
 try:
     from celery import shared_task
 except ImportError:
@@ -30,6 +28,7 @@ def send_mail(*args, **kwargs):
             countdown=retry_countdown,
             max_retries=max_retries,
         )
+
 
 @shared_task
 def send_template_mail(*args, **kwargs):

--- a/beproud/django/mailer/tasks.py
+++ b/beproud/django/mailer/tasks.py
@@ -24,7 +24,7 @@ def send_mail(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.send_mail(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return send_mail.retry(
             exc=e,
             countdown=retry_countdown,
@@ -37,7 +37,7 @@ def send_template_mail(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.send_template_mail(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return send_template_mail.retry(
             exc=e,
             countdown=retry_countdown,
@@ -51,7 +51,7 @@ def send_mass_mail(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.send_mass_mail(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return send_mass_mail.retry(
             exc=e,
             countdown=retry_countdown,
@@ -65,7 +65,7 @@ def mail_managers(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.mail_managers(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return mail_managers.retry(
             exc=e,
             countdown=retry_countdown,
@@ -79,7 +79,7 @@ def mail_managers_template(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.mail_managers_template(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return mail_managers_template.retry(
             exc=e,
             countdown=retry_countdown,
@@ -93,7 +93,7 @@ def mail_admins(*args, **kwargs):
     retry_countdown = kwargs.pop('retry_countdown', 10)
     try:
         mailer_api.mail_admins(*args, **kwargs)
-    except Exception, e:
+    except Exception as e:
         return mail_admins.retry(
             exc=e,
             countdown=retry_countdown,

--- a/beproud/django/mailer/tasks.py
+++ b/beproud/django/mailer/tasks.py
@@ -6,19 +6,6 @@ try:
 except ImportError:
     from celery.task import task as shared_task
 
-import celery
-
-if celery.VERSION < (3, 1):
-    try:
-        import djcelery  # NOQA
-    except ImportError:
-        from django.core.exceptions import ImproperlyConfigured
-        raise ImproperlyConfigured("when used celery<3.1, djcelery is required!")
-
-    if 'djcelery' not in settings.INSTALLED_APPS:
-        from django.core.exceptions import ImproperlyConfigured
-        raise ImproperlyConfigured("djcelery not in INSTALLED_APPS!")
-
 from beproud.django.mailer import api as mailer_api
 
 __all__ = (

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -961,11 +961,11 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
             u'本文',
             'example-from@example.net',
             ['example@example.net'],
-            attachments=[('test.txt', u"データ", None)],
+            attachments=[('test.txt', u"データ", 'text/plain')],
         )
 
         message = django_mail.outbox[0]
-        self.assertEquals(message.attachments, [('test.txt', u"データ", None)])
+        self.assertEquals(message.attachments, [('test.txt', u"データ", 'text/plain')])
 
     def test_send_template_mail(self):
         send_template_mail(
@@ -979,11 +979,11 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
             },
             fail_silently=False,
             html_template_name=u'mailer/html_mail.tpl',
-            attachments=[('test.txt', u"データ", None)],
+            attachments=[('test.txt', u"データ", 'text/plain')],
         )
 
         message = django_mail.outbox[0]
-        self.assertEquals(message.attachments, [('test.txt', u"データ", None)])
+        self.assertEquals(message.attachments, [('test.txt', u"データ", 'text/plain')])
 
     def test_binary_attachment(self):
         message = EmailMessage(

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -110,7 +110,7 @@ class EncodingTestCaseUTF8(MailTestCase, DjangoTestCase):
         self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example@example.net>")
         self.assertEqual(str(message['From']),
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
-        self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
+        self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
@@ -477,9 +477,6 @@ class DjangoMailISO2022JPTestCase(MailTestCase, DjangoTestCase):
 @override_settings(DEFAULT_CHARSET='utf-8')
 @override_settings(EMAIL_BACKEND='beproud.django.mailer.backends.locmem.EmailBackend')
 class DjangoMailUTF8TestCase(MailTestCase, DjangoTestCase):
-    # NOTE: Django の場合は "utf-8" に一致にしないと
-    #       Content-Transfer-Encodingがbase64になる
-
     def test_send_mail(self):
         django_mail.send_mail(
             u'件名',
@@ -494,7 +491,7 @@ class DjangoMailUTF8TestCase(MailTestCase, DjangoTestCase):
         self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example@example.net>")
         self.assertEqual(str(message['From']),
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
-        self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
+        self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
@@ -574,7 +571,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5a6b5YWI?= <example%s@example.net>" % i)
             self.assertEqual(str(message['From']),
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
-            self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
+            self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
             self.assertEqual(message.get_payload(), "5pys5paH\n")
 
@@ -638,7 +635,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example1@example.net>")
         self.assertEqual(str(message['From']),
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
-        self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
+        self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
@@ -791,7 +788,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5a6b5YWI?= <example%s@example.net>" % i)
             self.assertEqual(str(message['From']),
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
-            self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
+            self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
             self.assertEqual(message.get_payload(), "5pys5paH\n")
 
@@ -1005,7 +1002,7 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
 
         # 添付ファイルのペイロード
         self.assertEquals(len(payloads), 1)
-        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
+        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0]['Content-Disposition'], 'attachment; filename="test.txt"')
         self.assertEquals(payloads[0].get_payload(), "44OH44O844K/\n")
@@ -1042,10 +1039,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
 
         # text + html ペイロード
         self.assertEquals(len(payloads), 2)
-        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
+        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0].get_payload(), "5pys5paH\n")
-        self.assertEquals(payloads[1]['Content-Transfer-Encoding'], 'base64')
+        self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
         self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+\n")
 
@@ -1080,10 +1077,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
 
         # text + html ペイロード
         self.assertEquals(len(payloads), 2)
-        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
+        self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0].get_payload(), "5pys5paHCg==\n")
-        self.assertEquals(payloads[1]['Content-Transfer-Encoding'], 'base64')
+        self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
         self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+Cg==\n")
 

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -9,6 +9,7 @@ from itertools import chain
 from logging.handlers import BufferingHandler
 
 import mock
+import six
 
 from django.test import TestCase as DjangoTestCase
 from django.test import override_settings
@@ -112,7 +113,10 @@ class EncodingTestCaseUTF8(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        self.assertEqual(message.get_payload(), "5pys5paH\n")
+        if six.PY2:
+            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+        elif six.PY3:
+            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
 
     def test_cc(self):
         send_mail(
@@ -493,7 +497,10 @@ class DjangoMailUTF8TestCase(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        self.assertEqual(message.get_payload(), "5pys5paH\n")
+        if six.PY2:
+            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+        elif six.PY3:
+            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
@@ -573,7 +580,11 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-            self.assertEqual(message.get_payload(), "5pys5paH\n")
+            if six.PY2:
+                self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+            elif six.PY3:
+                self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+                
 
     def test_mass_mail_encoding(self):
         send_mass_mail(((
@@ -637,7 +648,10 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        self.assertEqual(message.get_payload(), "5pys5paH\n")
+        if six.PY2:
+            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+        elif six.PY3:
+            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
 
         message = django_mail.outbox[2].message()
         self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
@@ -790,7 +804,10 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-            self.assertEqual(message.get_payload(), "5pys5paH\n")
+            if six.PY2:
+                self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+            elif six.PY3:
+                self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
 
 
 
@@ -1005,7 +1022,10 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0]['Content-Disposition'], 'attachment; filename="test.txt"')
-        self.assertEquals(payloads[0].get_payload(), "44OH44O844K/\n")
+        if six.PY2:
+            self.assertEquals(payloads[0].get_payload(decode=True), "\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
+        elif six.PY3:
+            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
@@ -1041,10 +1061,16 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
-        self.assertEquals(payloads[0].get_payload(), "5pys5paH\n")
+        if six.PY2:
+            self.assertEquals(payloads[0].get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
+        elif six.PY3:
+            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
-        self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+\n")
+        if six.PY2:
+            self.assertEquals(payloads[1].get_payload(decode=True), "<h1>\xe6\x9c\xac\xe6\x96\x87</h1>")
+        elif six.PY3:
+            self.assertEquals(payloads[1].get_payload(decode=True), b"<h1>\xe6\x9c\xac\xe6\x96\x87</h1>")
 
     def test_html_template_mail(self):
         send_template_mail(
@@ -1079,10 +1105,16 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
-        self.assertEquals(payloads[0].get_payload(), "5pys5paHCg==\n")
+        if six.PY2:
+            self.assertEquals(payloads[0].get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87\n")
+        elif six.PY3:
+            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87\n")
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
-        self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+Cg==\n")
+        if six.PY2:
+            self.assertEquals(payloads[1].get_payload(decode=True), "<h1>\xe6\x9c\xac\xe6\x96\x87</h1>\n")
+        elif six.PY3:
+            self.assertEquals(payloads[1].get_payload(decode=True), b"<h1>\xe6\x9c\xac\xe6\x96\x87</h1>\n")
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -8,7 +8,6 @@ from itertools import chain
 from logging.handlers import BufferingHandler
 
 import mock
-import six
 
 from django.test import TestCase as DjangoTestCase
 from django.test import override_settings
@@ -194,10 +193,7 @@ class EncodingTestCaseUTF8(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        if six.PY2:
-            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-        elif six.PY3:
-            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+        self.assertEqual(message.get_payload(decode=True), u'本文'.encode('utf-8'))
 
     def test_cc(self):
         send_mail(
@@ -579,10 +575,7 @@ class DjangoMailUTF8TestCase(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        if six.PY2:
-            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-        elif six.PY3:
-            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+        self.assertEqual(message.get_payload(decode=True), u'本文'.encode('utf-8'))
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
@@ -662,10 +655,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-            if six.PY2:
-                self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-            elif six.PY3:
-                self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+            self.assertEqual(message.get_payload(decode=True), u'本文'.encode('utf-8'))
 
     def test_mass_mail_encoding(self):
         send_mass_mail(((
@@ -729,10 +719,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                          "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
         self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-        if six.PY2:
-            self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-        elif six.PY3:
-            self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+        self.assertEqual(message.get_payload(decode=True), u'本文'.encode('utf-8'))
 
         message = django_mail.outbox[2].message()
         self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
@@ -887,10 +874,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                              "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
             self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
-            if six.PY2:
-                self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-            elif six.PY3:
-                self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+            self.assertEqual(message.get_payload(decode=True), u'本文'.encode('utf-8'))
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
@@ -1092,10 +1076,7 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
         self.assertEquals(payloads[0]['Content-Type'], 'application/octet-stream')
         self.assertEquals(payloads[0]['Content-Disposition'], 'attachment; filename="test.binary"')
-        if six.PY2:
-            self.assertEquals(payloads[0].get_payload(decode=True), "\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
-        elif six.PY3:
-            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
+        self.assertEqual(payloads[0].get_payload(decode=True), u'データ'.encode('utf-8'))
 
     def test_text_attachment(self):
         message = EmailMessage(attachments=[('test.txt', u"データ", None)]).message()
@@ -1107,10 +1088,7 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0]['Content-Disposition'], 'attachment; filename="test.txt"')
-        if six.PY2:
-            self.assertEquals(payloads[0].get_payload(decode=True), "\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
-        elif six.PY3:
-            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe3\x83\x87\xe3\x83\xbc\xe3\x82\xbf")
+        self.assertEqual(payloads[0].get_payload(decode=True), u'データ'.encode('utf-8'))
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
@@ -1146,16 +1124,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
-        if six.PY2:
-            self.assertEquals(payloads[0].get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
-        elif six.PY3:
-            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
+        self.assertEquals(payloads[0].get_payload(decode=True), u"本文".encode("utf-8"))
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
-        if six.PY2:
-            self.assertEquals(payloads[1].get_payload(decode=True), "<h1>\xe6\x9c\xac\xe6\x96\x87</h1>")
-        elif six.PY3:
-            self.assertEquals(payloads[1].get_payload(decode=True), b"<h1>\xe6\x9c\xac\xe6\x96\x87</h1>")
+        self.assertEquals(payloads[1].get_payload(decode=True), u"<h1>本文</h1>".encode("utf-8"))
 
     def test_html_template_mail(self):
         send_template_mail(
@@ -1190,16 +1162,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
-        if six.PY2:
-            self.assertEquals(payloads[0].get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87\n")
-        elif six.PY3:
-            self.assertEquals(payloads[0].get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87\n")
+        self.assertEquals(payloads[0].get_payload(decode=True), u"本文\n".encode('utf-8'))
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], '8bit')
         self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
-        if six.PY2:
-            self.assertEquals(payloads[1].get_payload(decode=True), "<h1>\xe6\x9c\xac\xe6\x96\x87</h1>\n")
-        elif six.PY3:
-            self.assertEquals(payloads[1].get_payload(decode=True), b"<h1>\xe6\x9c\xac\xe6\x96\x87</h1>\n")
+        self.assertEquals(payloads[1].get_payload(decode=True), u"<h1>本文</h1>\n".encode('utf-8'))
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -2,10 +2,8 @@
 
 import os
 import time
-import copy
 import logging
 import unittest
-from email import charset
 from itertools import chain
 from logging.handlers import BufferingHandler
 
@@ -76,6 +74,7 @@ class MailTestCase(object):
         mail_pre_send.recievers = []
         mail_post_send.recievers = []
 
+
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
 @override_settings(MANAGERS=(('Manager', 'manager@example.net'),))
 @override_settings(DEFAULT_CHARSET='utf-8')
@@ -92,7 +91,7 @@ class EmailMessageEncodingTestCase(MailTestCase, DjangoTestCase):
         message = message_obj.message()
 
         self.assertEqual(message['Subject'], '=?utf-8?b?5Lu25ZCN?=')
-    
+
     def test_email_message_utf_8(self):
         message_obj = EmailMessage(
                 u'件名',
@@ -105,7 +104,7 @@ class EmailMessageEncodingTestCase(MailTestCase, DjangoTestCase):
 
         self.assertEqual(message['Subject'], '=?utf-8?b?5Lu25ZCN?=')
 
-    # FIXME 
+    # FIXME
     @unittest.skip("Py3.6から動かない")
     def test_email_message_utf_8_alias(self):
         message_obj = EmailMessage(
@@ -119,7 +118,7 @@ class EmailMessageEncodingTestCase(MailTestCase, DjangoTestCase):
 
         self.assertEqual(message['Subject'], '=?utf-8?b?5Lu25ZCN?=')
 
-    # FIXME 
+    # FIXME
     @unittest.skip("Py3.6から動かない")
     def test_email_message_cp932_alias_sjis(self):
         message_obj = EmailMessage(
@@ -156,6 +155,7 @@ class EmailMessageEncodingTestCase(MailTestCase, DjangoTestCase):
         message = message_obj.message()
 
         self.assertEquals(message['Subject'], '=?iso-2022-jp?b?GyRCN29MPhsoQg==?=')
+
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
 @override_settings(MANAGERS=(('Manager', 'manager@example.net'),))
@@ -531,6 +531,7 @@ class TemplateContextTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(str(message['From']),
                           '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
+
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
 @override_settings(MANAGERS=(('Manager', 'manager@example.net'),))
 @override_settings(DEFAULT_CHARSET='iso-2022-jp')
@@ -594,8 +595,8 @@ class SignalTest(MailTestCase, DjangoTestCase):
     def test_pre_send_signal(self):
         def pre_send_signal(sender, message, **kwargs):
             message.from_email = message.from_email.replace(u'\uff5e', u'\u301c')
-            message.to = [ x.replace(u'\uff5e', u'\u301c') for x in message.to ]
-            message.bcc = [ x.replace(u'\uff5e', u'\u301c') for x in message.bcc ]
+            message.to = [x.replace(u'\uff5e', u'\u301c') for x in message.to]
+            message.bcc = [x.replace(u'\uff5e', u'\u301c') for x in message.bcc]
             message.subject = message.subject.replace(u'\uff5e', u'\u301c')
             message.body = message.body.replace(u'\uff5e', u'\u301c')
         mail_pre_send.connect(pre_send_signal)
@@ -665,7 +666,6 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                 self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
             elif six.PY3:
                 self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
-                
 
     def test_mass_mail_encoding(self):
         send_mass_mail(((
@@ -744,7 +744,7 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
-    # FIXME 
+    # FIXME
     @unittest.skip("Py3.6から動かない")
     def test_mass_mail_encoding_inline2(self):
         send_mass_mail((
@@ -891,7 +891,6 @@ class MassMailTest(MailTestCase, DjangoTestCase):
                 self.assertEqual(message.get_payload(decode=True), "\xe6\x9c\xac\xe6\x96\x87")
             elif six.PY3:
                 self.assertEqual(message.get_payload(decode=True), b"\xe6\x9c\xac\xe6\x96\x87")
-
 
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))

--- a/beproud/django/mailer/tests.py
+++ b/beproud/django/mailer/tests.py
@@ -92,7 +92,7 @@ class EncodingTestCaseUTF8(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'example@example.net')
         self.assertEquals(str(message['From']), 'example-from@example.net')
 
@@ -106,12 +106,12 @@ class EncodingTestCaseUTF8(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?UTF-8?b?5Lu25ZCN?=")
-        self.assertEqual(str(message['To']), "=?UTF-8?b?5a6b5YWI?= <example@example.net>")
+        self.assertEqual(str(message['Subject']), "=?utf-8?b?5Lu25ZCN?=")
+        self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
+                         "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
     def test_cc(self):
@@ -170,7 +170,7 @@ class EncodingTestCaseISO2022JP(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'example@example.net')
         self.assertEquals(str(message['From']), 'example-from@example.net')
 
@@ -186,11 +186,11 @@ class EncodingTestCaseISO2022JP(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=')
+        self.assertEquals(str(message['Subject']), '=?iso-2022-jp?b?GyRCN29MPhsoQg==?=')
         self.assertEquals(str(message['To']),
-                          '=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example@example.net>')
+                          '=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>')
+                          '=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>')
 
     def test_email_charset_strict(self):
         send_mail(
@@ -202,13 +202,13 @@ class EncodingTestCaseISO2022JP(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
 
@@ -230,7 +230,7 @@ class EmailAllForwardTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'all-forward@example.net')
         self.assertEquals(str(message['From']), 'all-forward@example.net')
 
@@ -254,7 +254,7 @@ class EmailAllForwardTestCase2(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'example@example.net')
         self.assertEquals(str(message['From']), 'example-from@example.net')
 
@@ -282,10 +282,10 @@ class TemplateTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文\n')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
-        self.assertEquals(str(message['To']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['To']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
     def test_multi_line_subject(self):
         send_template_mail(
@@ -307,10 +307,10 @@ class TemplateTestCase(MailTestCase, DjangoTestCase):
 
         message = mail_message.message()
         self.assertEquals(str(message['Subject']),
-                          '=?UTF-8?b?44GT44KM44Gv5pS56KGM44Gu44GC44KL5Lu25ZCN?=')
-        self.assertEquals(str(message['To']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+                          '=?utf-8?b?44GT44KM44Gv5pS56KGM44Gu44GC44KL5Lu25ZCN?=')
+        self.assertEquals(str(message['To']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
     def test_cc(self):
         send_template_mail(
@@ -331,10 +331,10 @@ class TemplateTestCase(MailTestCase, DjangoTestCase):
 
         message = mail_message.message()
         self.assertEquals(str(message['To']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
-        self.assertEquals(str(message['Cc']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+        self.assertEquals(str(message['Cc']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
     def test_bcc(self):
         send_template_mail(
@@ -355,9 +355,9 @@ class TemplateTestCase(MailTestCase, DjangoTestCase):
 
         message = mail_message.message()
         self.assertEquals(str(message['To']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
         # Bcc is not included in email headers
         self.assertEquals(message['Bcc'], None)
@@ -387,10 +387,10 @@ class TemplateContextTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[0].body, u'本文\n')
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
-        self.assertEquals(str(message['To']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['To']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
     def test_email_default_context_override(self):
         send_template_mail(
@@ -409,9 +409,9 @@ class TemplateContextTestCase(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
         self.assertEquals(str(message['Subject']), 'overwrite')
-        self.assertEquals(str(message['To']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+        self.assertEquals(str(message['To']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
     def test_email_default_context_overwrite(self):
         send_template_mail(
@@ -441,10 +441,10 @@ class TemplateContextTestCase(MailTestCase, DjangoTestCase):
         self.assertEquals(django_mail.outbox[1].body, u'本文\n')
 
         message = django_mail.outbox[1].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
-        self.assertEquals(str(message['To']), '=?UTF-8?b?5a6b5YWI?= <example@example.net>')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['To']), '=?utf-8?b?5a6b5YWI?= <example@example.net>')
         self.assertEquals(str(message['From']),
-                          '=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
+                          '=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>')
 
 @override_settings(ADMINS=(('Admin', 'admin@example.net'),))
 @override_settings(MANAGERS=(('Manager', 'manager@example.net'),))
@@ -462,13 +462,13 @@ class DjangoMailISO2022JPTestCase(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
 
@@ -490,12 +490,12 @@ class DjangoMailUTF8TestCase(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?UTF-8?b?5Lu25ZCN?=")
-        self.assertEqual(str(message['To']), "=?UTF-8?b?5a6b5YWI?= <example@example.net>")
+        self.assertEqual(str(message['Subject']), "=?utf-8?b?5Lu25ZCN?=")
+        self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
+                         "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
 
@@ -509,8 +509,8 @@ class SignalTest(MailTestCase, DjangoTestCase):
     def test_pre_send_signal(self):
         def pre_send_signal(sender, message, **kwargs):
             message.from_email = message.from_email.replace(u'\uff5e', u'\u301c')
-            message.to = map(lambda x: x.replace(u'\uff5e', u'\u301c'), message.to)
-            message.bcc = map(lambda x: x.replace(u'\uff5e', u'\u301c'), message.bcc)
+            message.to = [ x.replace(u'\uff5e', u'\u301c') for x in message.to ]
+            message.bcc = [ x.replace(u'\uff5e', u'\u301c') for x in message.bcc ]
             message.subject = message.subject.replace(u'\uff5e', u'\u301c')
             message.body = message.body.replace(u'\uff5e', u'\u301c')
         mail_pre_send.connect(pre_send_signal)
@@ -524,13 +524,13 @@ class SignalTest(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8!A%F%9%H\x1b(B")
 
     def test_post_send_signal(self):
@@ -569,13 +569,13 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         for i in range(10):
             message = django_mail.outbox[i].message()
 
-            self.assertEqual(str(message['Subject']), "=?UTF-8?b?5Lu25ZCN?=")
+            self.assertEqual(str(message['Subject']), "=?utf-8?b?5Lu25ZCN?=")
             self.assertEqual(str(message['To']),
-                             "=?UTF-8?b?5a6b5YWI?= <example%s@example.net>" % i)
+                             "=?utf-8?b?5a6b5YWI?= <example%s@example.net>" % i)
             self.assertEqual(str(message['From']),
-                             "=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
+                             "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
-            self.assertEqual(message['Content-Type'], 'text/plain; charset="UTF-8"')
+            self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
             self.assertEqual(message.get_payload(), "5pys5paH\n")
 
     def test_mass_mail_encoding(self):
@@ -589,13 +589,13 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         for i in range(10):
             message = django_mail.outbox[i].message()
 
-            self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+            self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
             self.assertEqual(str(message['To']),
-                             "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example%s@example.net>" % i)
+                             "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example%s@example.net>" % i)
             self.assertEqual(str(message['From']),
-                             "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                             "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-            self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+            self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
             self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
     def test_mass_mail_encoding_inline(self):
@@ -624,32 +624,32 @@ class MassMailTest(MailTestCase, DjangoTestCase):
 
         message = django_mail.outbox[0].message()
 
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example0@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example0@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
         message = django_mail.outbox[1].message()
-        self.assertEqual(str(message['Subject']), "=?UTF-8?b?5Lu25ZCN?=")
-        self.assertEqual(str(message['To']), "=?UTF-8?b?5a6b5YWI?= <example1@example.net>")
+        self.assertEqual(str(message['Subject']), "=?utf-8?b?5Lu25ZCN?=")
+        self.assertEqual(str(message['To']), "=?utf-8?b?5a6b5YWI?= <example1@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
+                         "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEqual(message.get_payload(), "5pys5paH\n")
 
         message = django_mail.outbox[2].message()
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example2@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example2@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
     def test_mass_mail_encoding_inline2(self):
@@ -677,32 +677,32 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         ), encoding='cp932')
 
         message = django_mail.outbox[0].message()
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example0@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example0@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
         message = django_mail.outbox[1].message()
-        self.assertEqual(str(message['Subject']), "=?SHIFT-JIS?b?jI+WvA==?=")
-        self.assertEqual(str(message['To']), "=?SHIFT-JIS?b?iLaQ5g==?= <example1@example.net>")
+        self.assertEqual(str(message['Subject']), "=?shift-jis?b?jI+WvA==?=")
+        self.assertEqual(str(message['To']), "=?shift-jis?b?iLaQ5g==?= <example1@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?SHIFT-JIS?b?jbePb5Bs?= <example-from@example.net>")
+                         "=?shift-jis?b?jbePb5Bs?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '8bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="SHIFT-JIS"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="shift-jis"')
         self.assertEqual(message.get_payload(), "\x96{\x95\xb6")
 
         message = django_mail.outbox[2].message()
-        self.assertEqual(str(message['Subject']), "=?ISO-2022-JP?b?GyRCN29MPhsoQg==?=")
+        self.assertEqual(str(message['Subject']), "=?iso-2022-jp?b?GyRCN29MPhsoQg==?=")
         self.assertEqual(str(message['To']),
-                         "=?ISO-2022-JP?b?GyRCMDhAaBsoQg==?= <example2@example.net>")
+                         "=?iso-2022-jp?b?GyRCMDhAaBsoQg==?= <example2@example.net>")
         self.assertEqual(str(message['From']),
-                         "=?ISO-2022-JP?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
+                         "=?iso-2022-jp?b?GyRCOjk9UD9NGyhC?= <example-from@example.net>")
         self.assertEqual(message['Content-Transfer-Encoding'], '7bit')
-        self.assertEqual(message['Content-Type'], 'text/plain; charset="ISO-2022-JP"')
+        self.assertEqual(message['Content-Type'], 'text/plain; charset="iso-2022-jp"')
         self.assertEqual(message.get_payload(), "\x1b$BK\\J8\x1b(B")
 
     def test_mass_mail_pre_send(self):
@@ -786,13 +786,13 @@ class MassMailTest(MailTestCase, DjangoTestCase):
         for i in range(10):
             message = django_mail.outbox[i].message()
 
-            self.assertEqual(str(message['Subject']), "=?UTF-8?b?5Lu25ZCN?=")
+            self.assertEqual(str(message['Subject']), "=?utf-8?b?5Lu25ZCN?=")
             self.assertEqual(str(message['To']),
-                             "=?UTF-8?b?5a6b5YWI?= <example%s@example.net>" % i)
+                             "=?utf-8?b?5a6b5YWI?= <example%s@example.net>" % i)
             self.assertEqual(str(message['From']),
-                             "=?UTF-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
+                             "=?utf-8?b?5beu5Ye65Lq6?= <example-from@example.net>")
             self.assertEqual(message['Content-Transfer-Encoding'], 'base64')
-            self.assertEqual(message['Content-Type'], 'text/plain; charset="UTF-8"')
+            self.assertEqual(message['Content-Type'], 'text/plain; charset="utf-8"')
             self.assertEqual(message.get_payload(), "5pys5paH\n")
 
 
@@ -1006,7 +1006,7 @@ class AttachmentTestCase(MailTestCase, DjangoTestCase):
         # 添付ファイルのペイロード
         self.assertEquals(len(payloads), 1)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
-        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0]['Content-Disposition'], 'attachment; filename="test.txt"')
         self.assertEquals(payloads[0].get_payload(), "44OH44O844K/\n")
 
@@ -1034,7 +1034,7 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertTrue((u"<h1>本文</h1>", "text/html") in email_message.alternatives)
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'example@example.net')
         self.assertEquals(str(message['From']), 'example-from@example.net')
 
@@ -1043,10 +1043,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         # text + html ペイロード
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
-        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0].get_payload(), "5pys5paH\n")
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], 'base64')
-        self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="UTF-8"')
+        self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
         self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+\n")
 
     def test_html_template_mail(self):
@@ -1072,7 +1072,7 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         self.assertTrue((u"<h1>本文</h1>\n", "text/html") in email_message.alternatives)
 
         message = django_mail.outbox[0].message()
-        self.assertEquals(str(message['Subject']), '=?UTF-8?b?5Lu25ZCN?=')
+        self.assertEquals(str(message['Subject']), '=?utf-8?b?5Lu25ZCN?=')
         self.assertEquals(str(message['To']), 'example@example.net')
         self.assertEquals(str(message['From']), 'example-from@example.net')
 
@@ -1081,10 +1081,10 @@ class HtmlMailTestCase(MailTestCase, DjangoTestCase):
         # text + html ペイロード
         self.assertEquals(len(payloads), 2)
         self.assertEquals(payloads[0]['Content-Transfer-Encoding'], 'base64')
-        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="UTF-8"')
+        self.assertEquals(payloads[0]['Content-Type'], 'text/plain; charset="utf-8"')
         self.assertEquals(payloads[0].get_payload(), "5pys5paHCg==\n")
         self.assertEquals(payloads[1]['Content-Transfer-Encoding'], 'base64')
-        self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="UTF-8"')
+        self.assertEquals(payloads[1]['Content-Type'], 'text/html; charset="utf-8"')
         self.assertEquals(payloads[1].get_payload(), "PGgxPuacrOaWhzwvaDE+Cg==\n")
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,8 @@ setup(
     include_package_data=True,
     packages=find_packages(),
     namespace_packages=['beproud', 'beproud.django'],
-    install_requires=['Django>=1.2'],
-    tests_require=['celery>=2.2.7', 'mock>=0.7.2'],
+    install_requires=['Django>=1.8'],
+    tests_require=['celery>=4.1', 'mock>=0.7.2'],
     test_suite='tests.main',
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html)
 try:
     import multiprocessing  # NOQA
-except ImportError, e:
+except ImportError:
     pass
 
 import sys
@@ -21,7 +21,7 @@ try:
             sys.path.append(os.path.join(current_dir, fn))
 
     import billiard  # NOQA
-except ImportError, e:
+except ImportError:
     pass
 
 ############## End Hack ################

--- a/tests.py
+++ b/tests.py
@@ -28,22 +28,21 @@ def main():
         }
     }
 
-    if django.VERSION > (1, 8):
-        global_settings.TEMPLATES = [
-            {
-                'BACKEND': 'django.template.backends.django.DjangoTemplates',
-                'DIRS': [],
-                'APP_DIRS': True,
-                'OPTIONS': {
-                    'context_processors': [
-                        'django.template.context_processors.debug',
-                        'django.template.context_processors.request',
-                        'django.contrib.auth.context_processors.auth',
-                        'django.contrib.messages.context_processors.messages',
-                    ],
-                },
+    global_settings.TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
             },
-        ]
+        },
+    ]
 
     # For Celery Tests
     global_settings.CELERY_ALWAYS_EAGER = True
@@ -54,21 +53,14 @@ def main():
     app.config_from_object('django.conf:settings')
     app.autodiscover_tasks(lambda: global_settings.INSTALLED_APPS)
 
-    if django.VERSION > (1, 7):
-        django.setup()
+    django.setup()
 
     from django.test.utils import get_runner
     test_runner = get_runner(global_settings)
 
-    if django.VERSION > (1, 2):
-        test_runner = test_runner()
-        if django.VERSION > (1, 6):
-            tests = ['beproud.django.mailer']
-        else:
-            tests = ['mailer']
-        failures = test_runner.run_tests(tests)
-    else:
-        failures = test_runner(['mailer'], verbosity=1)
+    test_runner = test_runner()
+    tests = ['beproud.django.mailer']
+    failures = test_runner.run_tests(tests)
 
     sys.exit(failures)
 

--- a/tests.py
+++ b/tests.py
@@ -50,12 +50,9 @@ def main():
     global_settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
 
     import celery
-    if celery.VERSION >= (3, 1):
-        app = celery.Celery()
-        app.config_from_object('django.conf:settings')
-        app.autodiscover_tasks(lambda: global_settings.INSTALLED_APPS)
-    else:
-        global_settings.INSTALLED_APPS += ('djcelery',)
+    app = celery.Celery()
+    app.config_from_object('django.conf:settings')
+    app.autodiscover_tasks(lambda: global_settings.INSTALLED_APPS)
 
     if django.VERSION > (1, 7):
         django.setup()

--- a/tests.py
+++ b/tests.py
@@ -64,5 +64,6 @@ def main():
 
     sys.exit(failures)
 
+
 if __name__ == '__main__':
     main()

--- a/tests.py
+++ b/tests.py
@@ -45,12 +45,12 @@ def main():
     ]
 
     # For Celery Tests
-    global_settings.CELERY_ALWAYS_EAGER = True
-    global_settings.CELERY_EAGER_PROPAGATES_EXCEPTIONS = True
+    global_settings.CELERY_TASK_ALWAYS_EAGER = True
+    global_settings.CELERY_TASK_EAGER_PROPAGATES = True
 
     import celery
     app = celery.Celery()
-    app.config_from_object('django.conf:settings')
+    app.config_from_object('django.conf:settings', namespace='CELERY')
     app.autodiscover_tasks(lambda: global_settings.INSTALLED_APPS)
 
     django.setup()

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,5 @@ basepython =
     py27: python2.7
 deps =
     django18: Django>=1.8,<1.9
-    django18: celery>=3.0,<4.0
+    django18: celery>=4.0,<4.2
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = py27-django{12,13,14,15,16}, py27-django{17,18}, py27-celery{22,30}
+envlist = py27-django{12,13,14,15,16}, py27-django{17,18}
 
 [testenv]
 basepython =
@@ -9,7 +9,7 @@ basepython =
 deps =
     django12: Django>=1.2,<1.3
     django12: celery>=3.0,<4.0
-    django13: Django>=1.3,<1.4
+    django13: Django>=1.0,<1.4
     django13: celery>=3.0,<4.0
     django14: Django>=1.4,<1.5
     django14: celery>=3.0,<4.0
@@ -21,10 +21,4 @@ deps =
     django17: celery>=3.0,<4.0
     django18: Django>=1.8,<1.9
     django18: celery>=3.0,<4.0
-    celery22: Django>=1.7,<1.8
-    celery22: celery>=2.2,<3.0
-    celery22: django-celery>=2.2,<3.0
-    celery30: Django>=1.7,<1.8
-    celery30: celery>=3.0,<3.1
-    celery30: django-celery>=2.2,<3.0
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,12 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = py27-django{12,13,14,15,16}, py27-django{17,18}
+envlist = py27-django18
 
 [testenv]
 basepython =
     py27: python2.7
 deps =
-    django12: Django>=1.2,<1.3
-    django12: celery>=3.0,<4.0
-    django13: Django>=1.0,<1.4
-    django13: celery>=3.0,<4.0
-    django14: Django>=1.4,<1.5
-    django14: celery>=3.0,<4.0
-    django15: Django>=1.5,<1.6
-    django15: celery>=3.0,<4.0
-    django16: Django>=1.6,<1.7
-    django16: celery>=3.0,<4.0
-    django17: Django>=1.7,<1.8
-    django17: celery>=3.0,<4.0
     django18: Django>=1.8,<1.9
     django18: celery>=3.0,<4.0
 commands=python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,10 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = {py26,py27}-django{12,13,14,15,16}, py27-django{17,18}, py27-celery{22,30}
+envlist = py27-django{12,13,14,15,16}, py27-django{17,18}, py27-celery{22,30}
 
 [testenv]
 basepython =
-    py26: python2.6
     py27: python2.7
 deps =
     django12: Django>=1.2,<1.3

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = py27-django{18,111}
+envlist = py27-django{18,111}, py36-django111
 
 [testenv]
 basepython =
     py27: python2.7
+    py36: python3.6
 deps =
+    six
     django18: Django>=1.8,<1.9
     django18: celery>=4.0,<4.2
     django111: Django>=1.11,<2.0

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = py27-django{18,111}, py36-django111
+envlist = py27-django{18,111}, py36-django{18,111}
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # Requires tox > 1.8
 
 [tox]
-envlist = py27-django18
+envlist = py27-django{18,111}
 
 [testenv]
 basepython =
@@ -9,4 +9,6 @@ basepython =
 deps =
     django18: Django>=1.8,<1.9
     django18: celery>=4.0,<4.2
+    django111: Django>=1.11,<2.0
+    django111: celery>=4.0,<4.2
 commands=python setup.py test


### PR DESCRIPTION
* [x] py26のサポートdrop対応
* [x] celery2系, celery3.1のサポートdrop対応
* [x] django1.2 ~ 1.7のサポートdrop対応
* [x] celery3系のサポートdrop対応
* [x] celery4系のサポート対応追加
* [x] django1.11 サポート対応追加
* [x] py36 サポート対応追加(wip)
